### PR TITLE
Say hello

### DIFF
--- a/css/afz-unified-design.css
+++ b/css/afz-unified-design.css
@@ -268,6 +268,43 @@ img {
     transform: rotate(180deg);
 }
 
+/* Mobile refinements: make language control compact and non-distracting */
+@media (max-width: 768px) {
+    .professional-language-selector {
+        top: auto;
+        right: var(--space-3);
+        bottom: var(--space-3);
+    }
+
+    .language-dropdown-btn {
+        padding: var(--space-1) var(--space-2);
+        min-height: 36px;
+        font-size: 0.8rem;
+        background: rgba(17, 24, 39, 0.55);
+        border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    /* Hide label text on mobile to reduce visual noise */
+    .language-text,
+    .dropdown-arrow {
+        display: none;
+    }
+
+    /* Open the dropdown upward when docked near the bottom */
+    .language-dropdown-menu {
+        top: auto;
+        bottom: 100%;
+        right: 0;
+        margin-top: 0;
+        margin-bottom: var(--space-1);
+        transform: translateY(8px);
+    }
+
+    .language-dropdown-menu.open {
+        transform: translateY(0);
+    }
+}
+
 .language-dropdown-menu {
     position: absolute;
     top: 100%;


### PR DESCRIPTION
Add responsive CSS to prevent the language button from overlapping header titles on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f1c109f-cabe-49ed-ace4-1dcb44aa58ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f1c109f-cabe-49ed-ace4-1dcb44aa58ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

