### PR TITLE
Fix missing donate page payment method images

### DIFF
--- a/pages/donate.html
+++ b/pages/donate.html
@@ -288,11 +288,11 @@
                             <!-- Trust & Payment Methods -->
                             <div class="payment-trust" aria-label="Trusted Payment Methods" style="display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-top:8px;color:#6B7280;">
                                 <span style="font-weight:600;">We accept:</span>
-                                <img src="../images/payments/visa.svg" alt="Visa" style="height:24px;" />
-                                <img src="../images/payments/mastercard.svg" alt="Mastercard" style="height:24px;" />
-                                <img src="../images/payments/paypal.svg" alt="PayPal" style="height:24px;" />
-                                <img src="../images/payments/mtnmoney.svg" alt="MTN Mobile Money" style="height:24px;" />
-                                <img src="../images/payments/airtelmoney.svg" alt="Airtel Money" style="height:24px;" />
+                                <img src="../visa.svg" alt="Visa" style="height:24px;" />
+                                <img src="../mastercard.svg" alt="Mastercard" style="height:24px;" />
+                                <img src="../paypal.svg" alt="PayPal" style="height:24px;" />
+                                <img src="../mtnmoney.svg" alt="MTN Mobile Money" style="height:24px;" />
+                                <img src="../airtelmoney.svg" alt="Airtel Money" style="height:24px;" />
                                 <span aria-hidden="true" style="margin-left:auto;display:flex;align-items:center;gap:6px;">
                                     <span>SSL Secured</span>
                                     🔒


### PR DESCRIPTION
Fix broken image paths for payment logos on the donate page.

The previous image paths (`../images/payments/*.svg`) were incorrect, leading to payment logos (Visa, Mastercard, PayPal, MTN, Airtel) not displaying on `pages/donate.html`. This PR updates the paths to correctly reference the images from the project root.

---
<a href="https://cursor.com/background-agent?bcId=bc-76f53ab2-3a1a-4b9e-93c8-cedf0a0b748c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76f53ab2-3a1a-4b9e-93c8-cedf0a0b748c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

