### PR TITLE
Add funding partner logos to pages

### DIFF
--- a/css/afz-unified-design.css
+++ b/css/afz-unified-design.css
@@ -695,6 +695,60 @@ img {
 }
 
 /* ========================================
+   FUNDING PARTNERS STRIP
+   ======================================== */
+.funding-partners {
+    padding: var(--space-12) 0;
+    background: var(--gray-50);
+}
+
+.funding-partners .partners-header {
+    text-align: center;
+    margin-bottom: var(--space-6);
+}
+
+.funding-partners .partners-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--gray-700);
+    margin: 0;
+}
+
+.partners-logos {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--space-6);
+    align-items: center;
+}
+
+.partners-logos a,
+.partners-logos span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-4);
+    background: var(--afz-white);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid var(--gray-200);
+}
+
+.partners-logos img {
+    max-height: 40px;
+    width: auto;
+    border-radius: 0;
+}
+
+@media (max-width: 768px) {
+    .funding-partners {
+        padding: var(--space-8) 0;
+    }
+    .partners-logos img {
+        max-height: 32px;
+    }
+}
+
+/* ========================================
    RESPONSIVE DESIGN
    ======================================== */
 

--- a/images/partners/disability-rights-watch.svg
+++ b/images/partners/disability-rights-watch.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 60" role="img" aria-label="Disability Rights Watch logo placeholder">
+  <rect width="260" height="60" fill="#9333EA" rx="8"/>
+  <text x="130" y="36" font-family="Arial, Helvetica, sans-serif" font-size="16" fill="#FFFFFF" text-anchor="middle">Disability Rights Watch</text>
+</svg>

--- a/images/partners/grz.svg
+++ b/images/partners/grz.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img" aria-label="GRZ logo placeholder">
+  <rect width="200" height="60" fill="#166534" rx="8"/>
+  <text x="100" y="38" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#FFFFFF" text-anchor="middle">GRZ</text>
+</svg>

--- a/images/partners/sightsavers.svg
+++ b/images/partners/sightsavers.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img" aria-label="Sightsavers logo placeholder">
+  <rect width="200" height="60" fill="#F59E0B" rx="8"/>
+  <text x="100" y="38" font-family="Arial, Helvetica, sans-serif" font-size="22" fill="#000000" text-anchor="middle">Sightsavers</text>
+</svg>

--- a/images/partners/steps.svg
+++ b/images/partners/steps.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img" aria-label="STEPS logo placeholder">
+  <rect width="200" height="60" fill="#0EA5E9" rx="8"/>
+  <text x="100" y="38" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#FFFFFF" text-anchor="middle">STEPS</text>
+</svg>

--- a/images/partners/zafod.svg
+++ b/images/partners/zafod.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img" aria-label="ZAFOD logo placeholder">
+  <rect width="200" height="60" fill="#0F766E" rx="8"/>
+  <text x="100" y="38" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#FFFFFF" text-anchor="middle">ZAFOD</text>
+</svg>

--- a/images/partners/zapd.svg
+++ b/images/partners/zapd.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60" role="img" aria-label="ZAPD logo placeholder">
+  <rect width="200" height="60" fill="#1D4ED8" rx="8"/>
+  <text x="100" y="38" font-family="Arial, Helvetica, sans-serif" font-size="28" fill="#FFFFFF" text-anchor="middle">ZAPD</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -383,6 +383,34 @@
                 </div>
             </section>
 
+            <section class="funding-partners" aria-labelledby="funding-partners-title">
+                <div class="container">
+                    <div class="partners-header">
+                        <h2 id="funding-partners-title" class="partners-title">Funding Partners</h2>
+                    </div>
+                    <div class="partners-logos" role="list">
+                        <a href="https://zafod.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAFOD - Zambia Federation of Disability Organisations">
+                            <img src="./images/partners/zafod.svg" alt="ZAFOD logo">
+                        </a>
+                        <a href="https://www.zambia.gov.zm/" target="_blank" rel="noopener" role="listitem" aria-label="GRZ - Government of the Republic of Zambia">
+                            <img src="./images/partners/grz.svg" alt="GRZ crest">
+                        </a>
+                        <a href="https://zapd.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAPD - Zambia Agency for Persons with Disabilities">
+                            <img src="./images/partners/zapd.svg" alt="ZAPD logo">
+                        </a>
+                        <a href="https://disabilityrightswatch.net" target="_blank" rel="noopener" role="listitem" aria-label="Disability Rights Watch">
+                            <img src="./images/partners/disability-rights-watch.svg" alt="Disability Rights Watch logo">
+                        </a>
+                        <a href="https://steps.org.za" target="_blank" rel="noopener" role="listitem" aria-label="STEPS Clubfoot Care">
+                            <img src="./images/partners/steps.svg" alt="STEPS logo">
+                        </a>
+                        <a href="https://www.sightsavers.org/" target="_blank" rel="noopener" role="listitem" aria-label="Sightsavers">
+                            <img src="./images/partners/sightsavers.svg" alt="Sightsavers logo">
+                        </a>
+                    </div>
+                </div>
+            </section>
+
             <section>
                 <div class="container">
                     <h2>Latest News & Updates</h2>

--- a/pages/about.html
+++ b/pages/about.html
@@ -948,6 +948,33 @@
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
+            <section class="funding-partners" aria-labelledby="funding-partners-title">
+                <div class="container">
+                    <div class="partners-header">
+                        <h2 id="funding-partners-title" class="partners-title">Funding Partners</h2>
+                    </div>
+                    <div class="partners-logos" role="list">
+                        <a href="https://zafod.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAFOD - Zambia Federation of Disability Organisations">
+                            <img src="../images/partners/zafod.svg" alt="ZAFOD logo">
+                        </a>
+                        <a href="https://www.zambia.gov.zm/" target="_blank" rel="noopener" role="listitem" aria-label="GRZ - Government of the Republic of Zambia">
+                            <img src="../images/partners/grz.svg" alt="GRZ crest">
+                        </a>
+                        <a href="https://zapd.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAPD - Zambia Agency for Persons with Disabilities">
+                            <img src="../images/partners/zapd.svg" alt="ZAPD logo">
+                        </a>
+                        <a href="https://disabilityrightswatch.net" target="_blank" rel="noopener" role="listitem" aria-label="Disability Rights Watch">
+                            <img src="../images/partners/disability-rights-watch.svg" alt="Disability Rights Watch logo">
+                        </a>
+                        <a href="https://steps.org.za" target="_blank" rel="noopener" role="listitem" aria-label="STEPS Clubfoot Care">
+                            <img src="../images/partners/steps.svg" alt="STEPS logo">
+                        </a>
+                        <a href="https://www.sightsavers.org/" target="_blank" rel="noopener" role="listitem" aria-label="Sightsavers">
+                            <img src="../images/partners/sightsavers.svg" alt="Sightsavers logo">
+                        </a>
+                    </div>
+                </div>
+            </section>
             <div class="footer-content">
                 <div class="footer-section">
                     <img src="../favicon.jpg" alt="AFZ Logo" class="footer-logo">

--- a/pages/donate.html
+++ b/pages/donate.html
@@ -340,6 +340,33 @@
     <!-- Footer -->
     <footer class="site-footer" role="contentinfo">
         <div class="container">
+            <section class="funding-partners" aria-labelledby="funding-partners-title">
+                <div class="container">
+                    <div class="partners-header">
+                        <h2 id="funding-partners-title" class="partners-title">Funding Partners</h2>
+                    </div>
+                    <div class="partners-logos" role="list">
+                        <a href="https://zafod.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAFOD - Zambia Federation of Disability Organisations">
+                            <img src="../images/partners/zafod.svg" alt="ZAFOD logo">
+                        </a>
+                        <a href="https://www.zambia.gov.zm/" target="_blank" rel="noopener" role="listitem" aria-label="GRZ - Government of the Republic of Zambia">
+                            <img src="../images/partners/grz.svg" alt="GRZ crest">
+                        </a>
+                        <a href="https://zapd.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAPD - Zambia Agency for Persons with Disabilities">
+                            <img src="../images/partners/zapd.svg" alt="ZAPD logo">
+                        </a>
+                        <a href="https://disabilityrightswatch.net" target="_blank" rel="noopener" role="listitem" aria-label="Disability Rights Watch">
+                            <img src="../images/partners/disability-rights-watch.svg" alt="Disability Rights Watch logo">
+                        </a>
+                        <a href="https://steps.org.za" target="_blank" rel="noopener" role="listitem" aria-label="STEPS Clubfoot Care">
+                            <img src="../images/partners/steps.svg" alt="STEPS logo">
+                        </a>
+                        <a href="https://www.sightsavers.org/" target="_blank" rel="noopener" role="listitem" aria-label="Sightsavers">
+                            <img src="../images/partners/sightsavers.svg" alt="Sightsavers logo">
+                        </a>
+                    </div>
+                </div>
+            </section>
             <div class="footer-content">
                 <div class="footer-section">
                     <h3 class="footer-title" data-translate="footer-contact">Contact Information</h3>

--- a/pages/programs.html
+++ b/pages/programs.html
@@ -881,6 +881,33 @@
     <!-- Footer -->
     <footer class="site-footer">
         <div class="container">
+            <section class="funding-partners" aria-labelledby="funding-partners-title">
+                <div class="container">
+                    <div class="partners-header">
+                        <h2 id="funding-partners-title" class="partners-title">Funding Partners</h2>
+                    </div>
+                    <div class="partners-logos" role="list">
+                        <a href="https://zafod.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAFOD - Zambia Federation of Disability Organisations">
+                            <img src="../images/partners/zafod.svg" alt="ZAFOD logo">
+                        </a>
+                        <a href="https://www.zambia.gov.zm/" target="_blank" rel="noopener" role="listitem" aria-label="GRZ - Government of the Republic of Zambia">
+                            <img src="../images/partners/grz.svg" alt="GRZ crest">
+                        </a>
+                        <a href="https://zapd.org.zm" target="_blank" rel="noopener" role="listitem" aria-label="ZAPD - Zambia Agency for Persons with Disabilities">
+                            <img src="../images/partners/zapd.svg" alt="ZAPD logo">
+                        </a>
+                        <a href="https://disabilityrightswatch.net" target="_blank" rel="noopener" role="listitem" aria-label="Disability Rights Watch">
+                            <img src="../images/partners/disability-rights-watch.svg" alt="Disability Rights Watch logo">
+                        </a>
+                        <a href="https://steps.org.za" target="_blank" rel="noopener" role="listitem" aria-label="STEPS Clubfoot Care">
+                            <img src="../images/partners/steps.svg" alt="STEPS logo">
+                        </a>
+                        <a href="https://www.sightsavers.org/" target="_blank" rel="noopener" role="listitem" aria-label="Sightsavers">
+                            <img src="../images/partners/sightsavers.svg" alt="Sightsavers logo">
+                        </a>
+                    </div>
+                </div>
+            </section>
             <div class="footer-content">
                 <div class="footer-section">
                     <h3 class="footer-title" data-translate="footer-about-title">Albinism Foundation of Zambia - AFZ</h3>


### PR DESCRIPTION
Add a 'Funding Partners' section with placeholder logos and links to the homepage and key subpages.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3412915-d712-4cbe-a98d-7e4852691377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3412915-d712-4cbe-a98d-7e4852691377">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

